### PR TITLE
fix: optional chaining in case `obj?.property[0]` if obj is undefined

### DIFF
--- a/acorn/expression.js
+++ b/acorn/expression.js
@@ -343,7 +343,7 @@ pp.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow,
     }
     node.computed = !!computed
     if (optionalSupported) {
-      node.optional = optional
+      node.optional = optional || node.object.optional;
     }
     base = this.finishNode(node, "MemberExpression")
   } else if (!noCalls && this.eat(tt.parenL)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acorn-hammerhead",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "acorn.js parser adapted to TestCafe Hammerhead",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
https://github.com/DevExpress/testcafe-hammerhead/pull/2895